### PR TITLE
Changed the compiler version used by maven to Java6

### DIFF
--- a/shiro/pom.xml
+++ b/shiro/pom.xml
@@ -58,6 +58,16 @@
                       </execution>
                   </executions>
              </plugin>
+             
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-compiler-plugin</artifactId>
+                 <version>3.1</version>
+                 <configuration>
+                     <source>1.6</source>
+                     <target>1.6</target>
+                 </configuration>
+             </plugin>
         </plugins>
    </build>
 


### PR DESCRIPTION
The default version that maven uses might be different for different developers. For example, on my system the compilation failed because the Java version used by maven had no idea about annotations.
