### PR TITLE
fixed junit tests - changed BeforeClass to Before

### DIFF
--- a/src/generated-sources/java/shiro/interpreter/ShiroBaseListener.java
+++ b/src/generated-sources/java/shiro/interpreter/ShiroBaseListener.java
@@ -1,4 +1,4 @@
-// Generated from /Users/jeffreyguenther/Development/shiro/shiro/src/main/java/shiro/interpreter/Shiro.g4 by ANTLR 4.1
+// Generated from /home/elrond/Workspace/Code/Shiro/src/main/java/shiro/interpreter/Shiro.g4 by ANTLR 4.1
 package shiro.interpreter;
 
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/src/generated-sources/java/shiro/interpreter/ShiroLexer.java
+++ b/src/generated-sources/java/shiro/interpreter/ShiroLexer.java
@@ -1,4 +1,4 @@
-// Generated from /Users/jeffreyguenther/Development/shiro/shiro/src/main/java/shiro/interpreter/Shiro.g4 by ANTLR 4.1
+// Generated from /home/elrond/Workspace/Code/Shiro/src/main/java/shiro/interpreter/Shiro.g4 by ANTLR 4.1
 package shiro.interpreter;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.CharStream;

--- a/src/generated-sources/java/shiro/interpreter/ShiroListener.java
+++ b/src/generated-sources/java/shiro/interpreter/ShiroListener.java
@@ -1,4 +1,4 @@
-// Generated from /Users/jeffreyguenther/Development/shiro/shiro/src/main/java/shiro/interpreter/Shiro.g4 by ANTLR 4.1
+// Generated from /home/elrond/Workspace/Code/Shiro/src/main/java/shiro/interpreter/Shiro.g4 by ANTLR 4.1
 package shiro.interpreter;
 import org.antlr.v4.runtime.misc.NotNull;
 import org.antlr.v4.runtime.tree.ParseTreeListener;

--- a/src/generated-sources/java/shiro/interpreter/ShiroParser.java
+++ b/src/generated-sources/java/shiro/interpreter/ShiroParser.java
@@ -1,4 +1,4 @@
-// Generated from /Users/jeffreyguenther/Development/shiro/shiro/src/main/java/shiro/interpreter/Shiro.g4 by ANTLR 4.1
+// Generated from /home/elrond/Workspace/Code/Shiro/src/main/java/shiro/interpreter/Shiro.g4 by ANTLR 4.1
 package shiro.interpreter;
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;

--- a/src/test/java/shiro/ResultTupleTest.java
+++ b/src/test/java/shiro/ResultTupleTest.java
@@ -1,10 +1,12 @@
 package shiro;
 
-import java.util.HashSet;
-import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
-import org.junit.BeforeClass;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -12,7 +14,7 @@ import org.junit.Test;
  * @author jeffreyguenther
  */
 public class ResultTupleTest {
-    private static ResultTuple tuple;
+    private ResultTuple tuple;
     private static final String x = "x";
     private static final String y = "y";
     private static final String flag = "flag";
@@ -20,8 +22,8 @@ public class ResultTupleTest {
     public ResultTupleTest() {
     }
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
+    @Before
+    public void setUpClass() throws Exception {
         tuple = new ResultTuple();
     }
 
@@ -44,6 +46,9 @@ public class ResultTupleTest {
      */
     @Test
     public void testGetNames() {
+    	tuple.setNameforIndex(x, 0);
+        tuple.setNameforIndex(y, 1);
+        tuple.setNameforIndex(flag, 2);
         Set<String> names = new HashSet<String>();
         names.add(x);
         names.add(y);
@@ -72,6 +77,10 @@ public class ResultTupleTest {
      */
     @Test
     public void testSetGetValueForName() {
+    	tuple.setNameforIndex(x, 0);
+        tuple.setNameforIndex(y, 1);
+        tuple.setNameforIndex(flag, 2);
+    	
         tuple.setValueForName(x, Value.createInteger(23));
         tuple.setValueForName(y, Value.createFloat(4.5636f));
         tuple.setValueForName(flag, Value.createString("blues"));
@@ -114,6 +123,9 @@ public class ResultTupleTest {
      */
     @Test
     public void testToString() {
+        tuple.setValueForIndex(0, Value.createInteger(23));
+        tuple.setValueForIndex(1, Value.createFloat(4.5636f));
+        tuple.setValueForIndex(2, Value.createString("blues"));
         String expected = "23, 4.5636, blues";
         assertEquals(expected, tuple.toString());
     }
@@ -123,6 +135,13 @@ public class ResultTupleTest {
      */
     @Test
     public void testEquals() {
+        tuple.setValueForIndex(0, Value.createInteger(23));
+        tuple.setValueForIndex(1, Value.createFloat(4.5636f));
+        tuple.setValueForIndex(2, Value.createString("blues"));
+        tuple.setNameforIndex(x, 0);
+        tuple.setNameforIndex(y, 1);
+        tuple.setNameforIndex(flag, 2);
+    	
         ResultTuple t1 = ResultTuple.createTuple("elephants");
         t1.setValueForIndex(1, Value.createDouble(2.3d));
         ResultTuple t2 = ResultTuple.createTuple(23);

--- a/src/test/java/shiro/ValueTest.java
+++ b/src/test/java/shiro/ValueTest.java
@@ -3,172 +3,179 @@ package shiro;
 import junit.framework.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- *
+ * 
  * @author jeffreyguenther
  */
 public class ValueTest {
-    private static Value value;
-    
-    public ValueTest() {
-    }
+	private Value value;
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-        value = new Value("This is a test", String.class);
-    }
+	public ValueTest() {
+	}
 
-    /**
-     * Test of getType method, of class Value.
-     */
-    @Test
-    public void testGetType() {
-        assertEquals(String.class, value.getType());
-    }
+	@Before
+	public void setUpClass() {
+		value = new Value("This is a test", String.class);
+	}
 
-    /**
-     * Test of setType method, of class Value.
-     */
-    @Test
-    public void testSetType() {
-        value.setType(Float.class);
-        assertEquals(Float.class, value.getType());
-        value.setType(String.class);
-        assertEquals(String.class, value.getType());
-    }
+	/**
+	 * Test of getType method, of class Value.
+	 */
+	@Test
+	public void testGetType() {
+		assertEquals(String.class, value.getType());
+	}
 
-    /**
-     * Test of getValue method, of class Value.
-     */
-    @Test
-    public void testGetValue() {
-        value = Value.createString("This is a test");
-        if(value.getType().equals(String.class)){
-            String result = (String) value.getValue();
-            assertEquals("This is a test", result);
-        }else{
-            fail();
-        }
-        
-    }
+	/**
+	 * Test of setType method, of class Value.
+	 */
+	@Test
+	public void testSetType() {
+		value.setType(Float.class);
+		assertEquals(Float.class, value.getType());
+		value.setType(String.class);
+		assertEquals(String.class, value.getType());
+	}
 
-    /**
-     * Test of setValue method, of class Value.
-     */
-    @Test
-    public void testSetValue() {
-        String expected = "Mr. Magoo";
-        value.setValue(expected);
-        assertEquals(expected, value.getValueAsString());
-    }
+	/**
+	 * Test of getValue method, of class Value.
+	 */
+	@Test
+	public void testGetValue() {
+		value = Value.createString("This is a test");
+		if (value.getType().equals(String.class)) {
+			String result = (String) value.getValue();
+			assertEquals("This is a test", result);
+		} else {
+			fail();
+		}
 
-    /**
-     * Test of createInteger method, of class Value.
-     */
-    @Test
-    public void testCreateInteger() {
-        Integer expectedValue = 234;
-        value = Value.createInteger(expectedValue);
-        assertEquals(expectedValue, value.getValueAsInt());
-    }
-    
-    /**
-     * Test of getValueAsInt method, of class Value.
-     */
-    @Test
-    public void testGetValueAsInt() {
-        if(234 == value.getValueAsInt()){
-            assert true;
-        }else{
-            fail();
-        }
-    }
+	}
 
-    /**
-     * Test of createString method, of class Value.
-     */
-    @Test
-    public void testCreateString() {
-        String expectedValue = "Dog";
-        value = Value.createString(expectedValue);
-        assertEquals(expectedValue, value.getValueAsString());
-    }
-    
-    /**
-     * Test of getValueAsString method, of class Value.
-     */
-    @Test
-    public void testGetValueAsString() {
-        assertEquals("Dog", value.getValueAsString());
-    }
+	/**
+	 * Test of setValue method, of class Value.
+	 */
+	@Test
+	public void testSetValue() {
+		String expected = "Mr. Magoo";
+		value.setValue(expected);
+		assertEquals(expected, value.getValueAsString());
+	}
 
-    /**
-     * Test of createFloat method, of class Value.
-     */
-    @Test
-    public void testCreateFloat() {
-        Float expectedValue = 234.33435343f;
-        value = Value.createFloat(expectedValue);
-        assertEquals(expectedValue, value.getValueAsFloat());
-    }
+	/**
+	 * Test of createInteger method, of class Value.
+	 */
+	@Test
+	public void testCreateInteger() {
+		Integer expectedValue = 234;
+		value = Value.createInteger(expectedValue);
+		assertEquals(expectedValue, value.getValueAsInt());
+	}
 
-    
+	/**
+	 * Test of getValueAsInt method, of class Value.
+	 */
+	@Test
+	public void testGetValueAsInt() {
+		value = Value.createInteger(234);
+		if (234 == value.getValueAsInt()) {
+			assert true;
+		} else {
+			fail();
+		}
+	}
 
-    /**
-     * Test of getValueAsFloat method, of class Value.
-     */
-    @Test
-    public void testGetValueAsFloat() {
-        if(234.33435343f == value.getValueAsFloat()){
-            assert true;
-        }else{
-            fail();
-        }
-    }
-    
-    /**
-     * Test of createFloat method, of class Value.
-     */
-    @Test
-    public void testCreateDouble() {
-        Double expectedValue = -0.00034d;
-        value = Value.createDouble(expectedValue);
-        assertEquals(expectedValue, value.getValueAsDouble());
-    }
+	/**
+	 * Test of createString method, of class Value.
+	 */
+	@Test
+	public void testCreateString() {
+		String expectedValue = "Dog";
+		value = Value.createString(expectedValue);
+		assertEquals(expectedValue, value.getValueAsString());
+	}
 
-    /**
-     * Test of getValueAsDouble method, of class Value.
-     */
-    @Test
-    public void testGetValueAsDouble() {
-        if(-0.00034d == value.getValueAsDouble()){
-            assert true;
-        }else{
-            fail();
-        }
-    }
+	/**
+	 * Test of getValueAsString method, of class Value.
+	 */
+	@Test
+	public void testGetValueAsString() {
+		String expectedValue = "Dog";
+		value = Value.createString(expectedValue);
+		assertEquals("Dog", value.getValueAsString());
+	}
 
-    /**
-     * Test of equals method, of class Value.
-     */
-    @Test
-    public void testEquals() {
-        value = Value.createString("bananas");
-        Value v2 = Value.createInteger(23);
-        Value v3 = Value.createInteger(23);
-        Assert.assertNotSame(value, v2);
-        assertEquals(v2, v3);
-    }
+	/**
+	 * Test of createFloat method, of class Value.
+	 */
+	@Test
+	public void testCreateFloat() {
+		Float expectedValue = 234.33435343f;
+		value = Value.createFloat(expectedValue);
+		assertEquals(expectedValue, value.getValueAsFloat());
+	}
 
-    /**
-     * Test of toString method, of class Value.
-     */
-    @Test
-    public void testToString() {
-        value = Value.createString("bananas");
-        assertEquals("bananas", value.toString());
-    }
+	/**
+	 * Test of getValueAsFloat method, of class Value.
+	 */
+	@Test
+	public void testGetValueAsFloat() {
+		Float expectedValue = 234.33435343f;
+		value = Value.createFloat(expectedValue);
+		if (234.33435343f == value.getValueAsFloat()) {
+			assert true;
+		} else {
+			fail();
+		}
+	}
+
+	/**
+	 * Test of createFloat method, of class Value.
+	 */
+	@Test
+	public void testCreateDouble() {
+		Double expectedValue = -0.00034d;
+		value = Value.createDouble(expectedValue);
+		assertEquals(expectedValue, value.getValueAsDouble());
+	}
+
+	/**
+	 * Test of getValueAsDouble method, of class Value.
+	 */
+	@Test
+	public void testGetValueAsDouble() {
+		Double expectedValue = -0.00034d;
+		value = Value.createDouble(expectedValue);
+		if (-0.00034d == value.getValueAsDouble()) {
+			assert true;
+		} else {
+			fail();
+		}
+	}
+
+	/**
+	 * Test of equals method, of class Value.
+	 */
+	@Test
+	public void testEquals() {
+		value = Value.createString("bananas");
+		Value v2 = Value.createInteger(23);
+		Value v3 = Value.createInteger(23);
+		Assert.assertNotSame(value, v2);
+		assertEquals(v2, v3);
+	}
+
+	/**
+	 * Test of toString method, of class Value.
+	 */
+	@Test
+	public void testToString() {
+		value = Value.createString("bananas");
+		assertEquals("bananas", value.toString());
+	}
 }


### PR DESCRIPTION
The junit tests were using BeforeClass annotation to have initialization code. It should actually be @Before.

Also the tests relied on the order of the tests in source code which is not the order that JUNIT runs the tests. So, with this fix parts of code were moved to the test functions. This code can still be refactored to moved the common initialization codes into a function.
